### PR TITLE
feat: inplace-matrix-transpose

### DIFF
--- a/src/common/algorithm.cpp
+++ b/src/common/algorithm.cpp
@@ -7,7 +7,7 @@
 #include "./algorithm.hpp"
 
 template<typename RT, typename T>
-RT algorithm::_h::__naive_summation(big_size_t begin, big_size_t end, T *x) {
+RT algorithm::_h::naive_summation(big_size_t begin, big_size_t end, T *x) {
 
 	RT sum = 0;
 
@@ -19,18 +19,19 @@ RT algorithm::_h::__naive_summation(big_size_t begin, big_size_t end, T *x) {
 }
 
 template<typename RT, typename T>
-RT algorithm::_h::__pairwise_summation(big_size_t begin, big_size_t end, T *x) {
+RT algorithm::_h::pairwise_summation(big_size_t begin, big_size_t end, T *x) {
 
 	big_size_t n = (end - begin);
 
 	if (n <= 64) {
-		return algorithm::_h::__naive_summation<RT>(begin, end, x);
+		return algorithm::_h::naive_summation<RT>(begin, end, x);
 	}
 
 	else {
 		// big_size_t mid = n/2
-		return __pairwise_summation<RT>(begin, n / 2, x)
-				+ __pairwise_summation<RT>(begin, n - n / 2, x + n / 2);
+		return algorithm::_h::pairwise_summation<RT>(begin, n / 2, x)
+				+ algorithm::_h::pairwise_summation<RT>(begin, n - n / 2,
+						x + n / 2);
 	}
 }
 
@@ -38,7 +39,7 @@ RT algorithm::_h::__pairwise_summation(big_size_t begin, big_size_t end, T *x) {
 template<typename RT, typename T>
 RT algorithm::naive_summation(big_size_t begin, big_size_t end,
 		std::vector<T> vec) {
-	return algorithm::_h::__naive_summation<RT>(begin, end, &vec[0]);
+	return algorithm::_h::naive_summation<RT>(begin, end, &vec[0]);
 }
 
 /* Kahan summation, worst-case error that grows
@@ -71,7 +72,7 @@ template<typename RT, typename T>
 RT algorithm::pairwise_summation(big_size_t begin, big_size_t end,
 		std::vector<T> vec) {
 
-	return algorithm::_h::__pairwise_summation<RT>(begin, end, &vec[begin]);
+	return algorithm::_h::pairwise_summation<RT>(begin, end, &vec[begin]);
 }
 
 /*
@@ -111,7 +112,7 @@ RT algorithm::shift_reduce_sum(big_size_t begin, big_size_t end,
  * Time Complexity: O(n)
  * Space Complexity: O(MAX_EXTRA_SPACE) - Auxiliary Space, for n >= MAX_EXTRA_SPACE
  *
- * Very large constant factor: T(n) = 32 * log2(64) * n
+ * Comparatively large constant factor: T(n) = 32 * log2(64) * n
  */
 template<typename RT, typename T>
 RT algorithm::pairwise_selection_sum(big_size_t begin, big_size_t end,

--- a/src/common/algorithm.hpp
+++ b/src/common/algorithm.hpp
@@ -13,10 +13,10 @@
 
 namespace algorithm::_h {
 template<typename RT, typename T>
-RT __pairwise_summation(big_size_t begin, big_size_t end, T *x);
+RT pairwise_summation(big_size_t begin, big_size_t end, T *x);
 
 template<typename RT, typename T>
-RT __naive_summation(big_size_t begin, big_size_t end, T *x);
+RT naive_summation(big_size_t begin, big_size_t end, T *x);
 
 }
 

--- a/src/common/vec1d.cpp
+++ b/src/common/vec1d.cpp
@@ -479,8 +479,7 @@ void vec1d<T>::apply_in_range(big_size_t begin, big_size_t end,
  */
 template<typename T>
 T vec1d<T>::sum(big_size_t begin, big_size_t end) {
-	return algorithm::_h::__pairwise_summation<T>(begin, end,
-			&(this->values[0]));
+	return algorithm::_h::pairwise_summation<T>(begin, end, &(this->values[0]));
 }
 
 template<typename T>

--- a/src/iterators/RandomAccessNdIterator.cpp
+++ b/src/iterators/RandomAccessNdIterator.cpp
@@ -98,6 +98,40 @@ big_size_t RandomAccessNdIterator::reversed_index_at(
 	return reindex;
 }
 
+bool RandomAccessNdIterator::is_cycle_root(big_size_t index_1d) const {
+
+	big_size_t size = this->size();
+
+	big_size_t k = index_1d;
+	big_size_t xi = size;
+
+	big_size_t max_iter = 0;
+
+	while (true) {
+
+		xi = this->reversed_index_at(k);
+
+		if (xi == index_1d) {
+			break;
+		}
+
+		else if (xi < index_1d) {
+			return false;
+			break;
+		}
+
+		k = xi;
+
+		// debug
+		max_iter++;
+		if (max_iter == size) {
+			throw nd::exception(
+					"RandomAccessNdIterator::is_cycle_root(...), has been failed");
+		}
+	}
+
+	return true;
+}
 big_size_t RandomAccessNdIterator::size() const {
 	return this->attr.size1d;
 }

--- a/src/iterators/RandomAccessNdIterator.hpp
+++ b/src/iterators/RandomAccessNdIterator.hpp
@@ -38,6 +38,8 @@ public:
 
 	big_size_t reversed_index_at(big_size_t index_1d) const;
 
+	bool is_cycle_root(big_size_t index_1d) const;
+
 	virtual ~RandomAccessNdIterator();
 };
 

--- a/src/linalg/linalg.cpp
+++ b/src/linalg/linalg.cpp
@@ -303,12 +303,87 @@ nd::matrix<T> nd::linalg::transpose(nd::matrix<T, rf_h> mat, shape_t axes) {
 	return mat.permute(axes).copy();
 }
 
-//template<typename T, bool rf_h>
-//void nd::linalg::inplace_transpose(nd::matrix<T, rf_h> &mat, shape_t axes) {
-//
-//	// might be optional later
-//	if (!mat.own_data()) {
-//		throw nd::exception("nd::matrix, mat.own_data() == false");
-//	}
-//
-//}
+//inplace ops
+
+/*
+ * # 2D case,
+ *
+ * # shape = (N, M)
+ * # n = N * M
+ *
+ * [1]
+ *  space-complexity: O(1)
+ *  time-complexity: O(n^2)
+ *
+ * # might be extended later, to a partially-in-place-transpose
+ *
+ * [2] https://link.springer.com/content/pdf/10.1007%2F978-3-540-75755-9_68.pdf,
+ *
+ * 	space-complexity: O((N + M)/2) of a bit type (ex. std::bitset)
+ * 	time-complexity: O(n * log(n))
+ *
+ * [3] https://ctnzr.io/papers/PPoPP-2014.pdf,
+ *
+ *	space-complexity: O(max(N, M))
+ *	time-complexity: O(n)
+ *
+ *	---
+ *
+ *	A possible optimization for [1], is to use BABE (Burn At Both Ends)
+ *
+ *	i.e. RandomAccessNdIterator::reversed_index_at(...), and
+ *		 RandomAccessNdIterator::index_at(...), see also [2] section 3.
+ */
+template<typename T, bool rf_h>
+void nd::linalg::inplace::transpose(nd::matrix<T, rf_h> &mat, shape_t axes) {
+
+	// might be optional later
+	if (!mat.own_data()) {
+		throw nd::exception("nd::matrix, mat.own_data() == false");
+	}
+
+	big_size_t size = mat.size();
+	shape_t shape = mat.shape();
+
+	T *d = mat._m_begin();
+	big_size_t j, k, xi;
+
+	coords attr = mat._m_coords();
+	coords new_attr = attr.permuted(axes, true);
+
+	RandomAccessNdIterator rndIter(new_attr);
+
+	for (big_size_t i = 0; i < size; i++) {
+
+		T tmp = d[i];
+
+		k = i;
+		j = rndIter.index_at(i);
+		xi = size;
+
+		// no change
+		if (i == j) {
+			continue;
+		}
+
+		if (rndIter.is_cycle_root(i)) {
+
+			while (true) {
+
+				xi = rndIter.reversed_index_at(k);
+
+				if (xi == i) {
+					break;
+				}
+
+				std::swap(d[xi], tmp);
+				k = xi;
+			}
+
+			// xi = i
+			d[i] = tmp;
+		}
+	}
+
+	mat._m_permute_inplace(axes);
+}

--- a/src/linalg/linalg.hpp
+++ b/src/linalg/linalg.hpp
@@ -33,9 +33,6 @@ nd::matrix<RT> tensordot(const nd::matrix<T1, rf_h0> &m1,
 template<typename T, bool rf_h>
 nd::matrix<T> transpose(nd::matrix<T, rf_h> mat, shape_t axes);
 
-//template<typename T, bool rf_h>
-//void inplace_transpose(nd::matrix<T, rf_h> &mat, shape_t axes);
-
 template<typename RT, typename T, bool rf_h>
 nd::matrix<RT> inverse(nd::matrix<T, rf_h> mat);
 
@@ -44,6 +41,17 @@ nd::matrix<RT> pseudo_inverse(nd::matrix<T, rf_h> mat);
 
 //template<typename T>
 //nd::composite<nd::matrix<T>> eigen(nd::matrix<T> mat);
+
+}
+
+namespace nd::linalg::inplace {
+
+//template<typename T, bool rf_h>
+//void swapaxes(nd::matrix<T, rf_h> &mat, max_size_t ax0,
+//		max_size_t ax1);
+
+template<typename T, bool rf_h>
+void transpose(nd::matrix<T, rf_h> &mat, shape_t axes);
 
 }
 

--- a/src/multidim/matrix.hpp
+++ b/src/multidim/matrix.hpp
@@ -130,6 +130,7 @@ public:
 	// ===================
 
 	matrix<T, false> permute(shape_t axes);
+	void _m_permute_inplace(shape_t axes);
 
 	virtual ~_matrix();
 

--- a/src/multidim/matrix_ops.cpp
+++ b/src/multidim/matrix_ops.cpp
@@ -354,3 +354,10 @@ nd::matrix<T, false> nd::_matrix<T, ref_holder>::permute(shape_t axes) {
 	return mat_chunk;
 }
 
+template<typename T, bool ref_holder>
+void nd::_matrix<T, ref_holder>::_m_permute_inplace(shape_t axes) {
+
+	coords new_attr = this->attr.permuted(axes, true);
+	this->attr = coords(new_attr.shape);
+}
+

--- a/src/shapes/coords.cpp
+++ b/src/shapes/coords.cpp
@@ -170,6 +170,24 @@ coords coords::reverse_permute(bool own_data) const {
 	return new_attr;
 }
 
+coords coords::swapaxes(max_size_t ax0, max_size_t ax1, bool own_data) const {
+
+	if (ax0 >= this->ndim || ax1 >= this->ndim) {
+
+		throw nd::exception(
+				"Invalid axis of axes, ax0 >= this->ndim || ax1 >= this->ndim");
+	}
+
+	;
+	shape_t swapped_axes = this->axes;
+
+	std::swap(swapped_axes[ax0], swapped_axes[ax1]);
+
+	coords new_attr = this->permuted(swapped_axes, own_data);
+
+	return new_attr;
+}
+
 bool operator ==(const coords &attr1, const coords &attr2) {
 
 	coords temp1 = attr1;

--- a/src/shapes/coords.hpp
+++ b/src/shapes/coords.hpp
@@ -47,6 +47,7 @@ public:
 
 	coords permuted(const shape_t &axes, bool own_data) const;
 	coords reverse_permute(bool own_data) const;
+	coords swapaxes(max_size_t ax0, max_size_t ax1, bool own_data) const;
 
 	friend bool operator ==(const coords &attr1, const coords &attr2);
 

--- a/tests/test_api/api_main_test.cpp
+++ b/tests/test_api/api_main_test.cpp
@@ -25,9 +25,12 @@ int main() {
 //	test_api::linalg_transpose();
 
 // [6]
-	test_api::reorder_copy();
+//	test_api::reorder_copy();
 
 // [7]
+	test_api::linalg_inplace();
+
+// [8]
 //	test_api::linalg_lu();
 
 }

--- a/tests/test_api/linalg_inplace.cpp
+++ b/tests/test_api/linalg_inplace.cpp
@@ -1,0 +1,56 @@
+/*
+ * linalg_inplace.cpp
+ *
+ *	Author: Z. Mohamed
+ */
+
+#include "./test_api.hpp"
+
+void test_api::linalg_inplace() {
+
+	shape_t shape0 = { 3, 2 };
+	nd::matrix<int> mat0 = nd::random::uniform<int>(0, 5, shape0);
+
+	std::cout << "shape :" << mat0.shape() << ", own_data: " << mat0.own_data()
+			<< ln;
+	std::cout << "------------\n";
+
+	nd::out::print_matrix(mat0);
+
+	std::cout << "\n==============================\n";
+
+	//  nd::linalg::transpose<T>(nd::matrix<T> mat, axes = {...})
+	nd::linalg::inplace::transpose<int>(mat0, { 1, 0 });
+
+	nd::out::_h::print_vec1d(mat0._m_begin(), 0, mat0.size());
+
+	std::cout << "\n\n==============================\n";
+
+	shape_t shape = { 3, 2, 2, 2 };
+
+	nd::matrix<int> mat = nd::random::uniform<int>(0, 5, shape);
+
+	std::cout << "shape :" << mat.shape() << ", own_data :" << mat.own_data()
+			<< ln;
+
+	std::cout << "\n------------\n";
+	std::cout << "data : ";
+
+	nd::out::_h::print_vec1d(mat._m_begin(), 0, mat.size());
+
+	std::cout
+			<< "\n\n============ transposed, axes = { 3, 0, 1, 2 } =============\n";
+
+	nd::linalg::inplace::transpose<int>(mat, { 3, 0, 1, 2 });
+
+	std::cout << "shape :" << mat.shape() << ", own_data :" << mat.own_data()
+			<< ln;
+
+	std::cout << "\n------------\n";
+	std::cout << "data : ";
+
+	nd::out::_h::print_vec1d(mat._m_begin(), 0, mat.size());
+
+	std::cout << "\n=================================\n";
+
+}

--- a/tests/test_api/test_api.hpp
+++ b/tests/test_api/test_api.hpp
@@ -27,6 +27,7 @@ void linalg_lu();
 void linalg_echelon();
 void linalg_hessenberg();
 void reorder_copy();
+void linalg_inplace();
 
 }
 


### PR DESCRIPTION
might be extended later, to a partially-in-place-transpose

- [MIPT](https://link.springer.com/content/pdf/10.1007%2F978-3-540-75755-9_68.pdf)
- [A Decomposition for In-place Matrix Transposition](https://ctnzr.io/papers/PPoPP-2014.pdf)

> A possible optimization, is to use BABE (Burn At Both Ends)

```
 i.e. RandomAccessNdIterator::reversed_index_at(...), and
      RandomAccessNdIterator::index_at(...), see also [MIPT] section 3.
```